### PR TITLE
Add simple PHP team portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+uploads/
+data.sqlite

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# curly-dollop
-internal file sharing and data, file storing for between teams in a organization
+# Team Portal
+
+This is a simple internal messaging and file sharing system built with PHP and Bootstrap. It is designed for small teams that need to exchange messages and files on a shared hosting environment.
+
+## Features
+
+- User registration and login
+- Message board visible to all users
+- File upload and download
+- Uses SQLite for storage (single `data.sqlite` file)
+
+## Setup
+
+1. Upload all files to your hosting account.
+2. Run `install.php` once to create the database and a default admin account:
+   - **Username:** `admin`
+   - **Password:** `admin`
+3. Log in via `login.php` and start using the portal.
+4. Delete `install.php` after installation for security.
+
+Uploaded files are stored in the `uploads/` directory, which is excluded from version control.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,14 @@
+<?php
+// Configuration
+session_start();
+
+// Path to SQLite database file
+$dbFile = __DIR__ . '/data.sqlite';
+
+try {
+    $db = new PDO('sqlite:' . $dbFile);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (Exception $e) {
+    die('Could not connect to database: ' . $e->getMessage());
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,64 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Fetch messages
+$messages = $db->query('SELECT messages.content, messages.created_at, users.username FROM messages JOIN users ON messages.user_id = users.id ORDER BY messages.created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+
+// Fetch files
+$files = $db->query('SELECT files.id, files.filename, files.original_name, files.uploaded_at, users.username FROM files JOIN users ON files.user_id = users.id ORDER BY files.uploaded_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Team Portal</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+<h2>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?>!</h2>
+<a href="logout.php" class="btn btn-secondary mb-3">Logout</a>
+
+<h3>Post a Message</h3>
+<form method="post" action="message.php" class="mb-4">
+  <div class="mb-3">
+    <textarea name="content" class="form-control" required></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Send</button>
+</form>
+
+<h3>Upload a File</h3>
+<form method="post" action="upload.php" enctype="multipart/form-data" class="mb-4">
+  <div class="mb-3">
+    <input type="file" name="file" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Upload</button>
+</form>
+
+<h3>Messages</h3>
+<ul class="list-group mb-4">
+<?php foreach ($messages as $msg): ?>
+  <li class="list-group-item">
+    <strong><?php echo htmlspecialchars($msg['username']); ?>:</strong>
+    <?php echo nl2br(htmlspecialchars($msg['content'])); ?>
+    <br><small class="text-muted"><?php echo $msg['created_at']; ?></small>
+  </li>
+<?php endforeach; ?>
+</ul>
+
+<h3>Files</h3>
+<ul class="list-group">
+<?php foreach ($files as $file): ?>
+  <li class="list-group-item">
+    <a href="uploads/<?php echo urlencode($file['filename']); ?>" download>
+      <?php echo htmlspecialchars($file['original_name']); ?>
+    </a>
+    <br><small class="text-muted">Uploaded by <?php echo htmlspecialchars($file['username']); ?> on <?php echo $file['uploaded_at']; ?></small>
+  </li>
+<?php endforeach; ?>
+</ul>
+</body>
+</html>

--- a/install.php
+++ b/install.php
@@ -1,0 +1,37 @@
+<?php
+require 'config.php';
+
+// Create tables if they do not exist
+$db->exec("CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+);");
+
+$db->exec("CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    content TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);");
+
+$db->exec("CREATE TABLE IF NOT EXISTS files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER,
+    filename TEXT,
+    original_name TEXT,
+    uploaded_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(user_id) REFERENCES users(id)
+);");
+
+// If there are no users, create default admin
+$stmt = $db->query('SELECT COUNT(*) FROM users');
+if ($stmt->fetchColumn() == 0) {
+    $db->prepare('INSERT INTO users(username, password) VALUES (?, ?)')
+       ->execute(['admin', password_hash('admin', PASSWORD_DEFAULT)]);
+    echo "Created default admin user (username: admin, password: admin)\n";
+}
+
+echo "Installation complete.\n";
+?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,41 @@
+<?php
+require 'config.php';
+
+if (!empty($_POST['username']) && !empty($_POST['password'])) {
+    $stmt = $db->prepare('SELECT id, password FROM users WHERE username = ?');
+    $stmt->execute([$_POST['username']]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($_POST['password'], $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['username'] = $_POST['username'];
+        header('Location: index.php');
+        exit;
+    } else {
+        $error = 'Invalid credentials.';
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+<h2>Login</h2>
+<?php if (!empty($error)) echo '<div class="alert alert-danger">'.$error.'</div>'; ?>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+  <a href="register.php" class="btn btn-link">Register</a>
+</form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+require 'config.php';
+session_destroy();
+header('Location: login.php');
+exit;
+?>

--- a/message.php
+++ b/message.php
@@ -1,0 +1,13 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (!empty($_POST['content'])) {
+    $stmt = $db->prepare('INSERT INTO messages(user_id, content) VALUES (?, ?)');
+    $stmt->execute([$_SESSION['user_id'], $_POST['content']]);
+}
+header('Location: index.php');
+?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,41 @@
+<?php
+require 'config.php';
+
+if (!empty($_POST['username']) && !empty($_POST['password'])) {
+    $stmt = $db->prepare('INSERT INTO users(username, password) VALUES (?, ?)');
+    try {
+        $stmt->execute([
+            $_POST['username'],
+            password_hash($_POST['password'], PASSWORD_DEFAULT)
+        ]);
+        header('Location: login.php');
+        exit;
+    } catch (Exception $e) {
+        $error = 'Username already taken.';
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Register</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-5">
+<h2>Register</h2>
+<?php if (!empty($error)) echo '<div class="alert alert-danger">'.$error.'</div>'; ?>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" name="username" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Register</button>
+  <a href="login.php" class="btn btn-link">Login</a>
+</form>
+</body>
+</html>

--- a/upload.php
+++ b/upload.php
@@ -1,0 +1,21 @@
+<?php
+require 'config.php';
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (!empty($_FILES['file']['name'])) {
+    $uploadDir = __DIR__ . '/uploads/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0755, true);
+    }
+    $filename = uniqid() . '_' . basename($_FILES['file']['name']);
+    $targetFile = $uploadDir . $filename;
+    if (move_uploaded_file($_FILES['file']['tmp_name'], $targetFile)) {
+        $stmt = $db->prepare('INSERT INTO files(user_id, filename, original_name) VALUES (?, ?, ?)');
+        $stmt->execute([$_SESSION['user_id'], $filename, $_FILES['file']['name']]);
+    }
+}
+header('Location: index.php');
+?>


### PR DESCRIPTION
## Summary
- set up `.gitignore`
- add SQLite-based config and install script
- implement registration, login, logout
- implement message posting and file uploads
- main page to show messages and files
- update README with setup instructions

## Testing
- `php -l config.php`
- `php -l install.php`
- `php -l register.php`
- `php -l login.php`
- `php -l logout.php`
- `php -l message.php`
- `php -l upload.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68499d7c7ab0832ab350b06a77f60d8f