### PR TITLE
Add Discord-like dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Team Portal
 
-This is a simple internal messaging and file sharing system built with PHP and Bootstrap. It is designed for small teams that need to exchange messages and files on a shared hosting environment.
+This is a simple internal messaging and file sharing system built with PHP and Bootstrap. It now ships with a small custom stylesheet that applies a dark "Discord-like" appearance. The system is designed for small teams that need to exchange messages and files on a shared hosting environment.
 
 ## Features
 
@@ -8,6 +8,7 @@ This is a simple internal messaging and file sharing system built with PHP and B
 - Message board visible to all users
 - File upload and download
 - Uses SQLite for storage (single `data.sqlite` file)
+- Dark theme inspired by the Discord interface
 
 ## Setup
 

--- a/index.php
+++ b/index.php
@@ -17,6 +17,7 @@ $files = $db->query('SELECT files.id, files.filename, files.original_name, files
   <meta charset="utf-8">
   <title>Team Portal</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="container py-5">
 <h2>Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?>!</h2>

--- a/login.php
+++ b/login.php
@@ -21,6 +21,7 @@ if (!empty($_POST['username']) && !empty($_POST['password'])) {
   <meta charset="utf-8">
   <title>Login</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="container py-5">
 <h2>Login</h2>

--- a/register.php
+++ b/register.php
@@ -21,6 +21,7 @@ if (!empty($_POST['username']) && !empty($_POST['password'])) {
   <meta charset="utf-8">
   <title>Register</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="container py-5">
 <h2>Register</h2>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,25 @@
+body {
+  background-color: #36393f;
+  color: #dcddde;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.container {
+  max-width: 800px;
+}
+
+.btn-primary {
+  background-color: #7289da;
+  border-color: #7289da;
+}
+
+.list-group-item {
+  background-color: #2f3136;
+  border: 1px solid #202225;
+}
+
+.form-control {
+  background-color: #202225;
+  color: #dcddde;
+  border: 1px solid #2f3136;
+}


### PR DESCRIPTION
## Summary
- add a custom stylesheet with colors inspired by Discord
- apply the stylesheet to index, login, and register pages
- document the new theme in README

## Testing
- `php -l index.php login.php register.php message.php upload.php logout.php install.php config.php`

------
https://chatgpt.com/codex/tasks/task_e_684aa5f01be0832a8057fd6d0d5b031a